### PR TITLE
Simplify deterministic replay capsules

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:players": "node scripts/run-tests.mjs --only players",
     "test:actor-rigid": "node scripts/run-tests.mjs --only actor-rigid",
     "test:timing": "node scripts/run-tests.mjs --only timing",
+    "test:replay": "node scripts/run-tests.mjs --only replay-capsule",
     "test:anim": "node scripts/run-tests.mjs --only anim",
     "test:net": "node scripts/run-tests.mjs --only net",
     "test:net-protocol": "node scripts/run-tests.mjs --only net-protocol",

--- a/scripts/replay-capsule-test.mjs
+++ b/scripts/replay-capsule-test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import {
+  decodeReplayCapsule,
+  encodeReplayCapsule,
+  REPLAY_FORMAT,
+  REPLAY_PREFIX,
+  REPLAY_VERSION,
+  validateReplayCapsule,
+} from '../src/sand/game/replayCapsule.js';
+import {
+  ABI_FINGERPRINT,
+  ABI_VERSION,
+} from '../src/sand/wasmBridge/abi.generated.js';
+
+const capsule = {
+  format: REPLAY_FORMAT,
+  version: REPLAY_VERSION,
+  abiVersion: ABI_VERSION,
+  abiFingerprint: ABI_FINGERPRINT,
+  init: { cols: 256, rows: 192, worldSeed: 0x51f7, survival: false },
+  turns: 500_000,
+  events: [
+    {
+      tick: 12,
+      message: {
+        type: 'control', buttons: 1, inside: true, worldX: 120, worldY: 80,
+      },
+    },
+    {
+      tick: 28,
+      message: {
+        type: 'control', buttons: 0, inside: true, worldX: 120, worldY: 80,
+      },
+    },
+    { tick: 500_000, message: { type: 'config', paused: true } },
+  ],
+  gates: [
+    { start: 0, end: 2, flags: 1 },
+    { start: 400_000, end: 400_002, flags: 3 },
+  ],
+  view: { cameraWorldX: 100, cameraWorldY: 70, zoom: 1 },
+  final: {
+    tick: 500_000,
+    actorTick: 500_000,
+    cols: 256,
+    rows: 192,
+    gridHash: 0x12345678,
+    worldOffsetX: -256,
+    worldOffsetY: 128,
+  },
+};
+
+const text = encodeReplayCapsule(capsule);
+assert.ok(text.startsWith(`${REPLAY_PREFIX}{`));
+assert.ok(text.includes('"turns":500000'));
+assert.ok(text.includes('"events":[[12,'));
+assert.ok(!text.includes('gzip:'));
+assert.ok(text.length < 1_000, `plain replay text should stay event-sized, got ${text.length}`);
+assert.deepEqual(decodeReplayCapsule(`\n${text}\n`), capsule);
+
+const overlappingGates = {
+  ...capsule,
+  gates: [
+    { start: 10, end: 20, flags: 1 },
+    { start: 19, end: 21, flags: 2 },
+  ],
+};
+assert.throws(
+  () => validateReplayCapsule(overlappingGates),
+  /invalid transport gate range/,
+);
+assert.throws(() => decodeReplayCapsule('SAND-REPLAY-1:{}'), /SAND-REPLAY-2/);
+
+console.log('replay capsule plain-JSON round trip and sparse timeline: ok');

--- a/scripts/test-manifest.mjs
+++ b/scripts/test-manifest.mjs
@@ -81,6 +81,7 @@ export const UNIT_SUITES = [
   ['grounding', 'grounding-incremental-test.mjs', exclusive(180_000)],
   ['pure-perf', 'pure-perf-checksum-test.mjs', exclusive(480_000)],
   ['timing', 'timing-test.mjs'],
+  ['replay-capsule', 'replay-capsule-test.mjs'],
   ['worker-order', 'world-worker-order-test.mjs'],
   ['worker-liveness', 'worker-liveness-test.mjs'],
   ['viewport-pause', 'viewport-pause-test.mjs'],

--- a/scripts/worker-e2e.mjs
+++ b/scripts/worker-e2e.mjs
@@ -133,7 +133,7 @@ try {
   await page.keyboard.press('l');
   await page.waitForFunction(() => document.querySelector('sand-game').shadowRoot
     .querySelector('textarea[aria-label="Replay capsule text"]')?.value
-    .startsWith('SAND-REPLAY-1:'), null, { timeout: 30000 });
+    .startsWith('SAND-REPLAY-2:{'), null, { timeout: 30000 });
   const firstReplayTick = await page.evaluate(() => window.__sandPerf().worldTick);
   await page.keyboard.press('l');
   await page.waitForFunction((tick) => {
@@ -149,7 +149,7 @@ try {
   await page.keyboard.press('l');
   await page.waitForFunction(() => document.querySelector('sand-game').shadowRoot
     .querySelector('textarea[aria-label="Replay capsule text"]')?.value
-    .startsWith('SAND-REPLAY-1:'), null, { timeout: 30000 });
+    .startsWith('SAND-REPLAY-2:{'), null, { timeout: 30000 });
   const replayTick = await page.evaluate(() => window.__sandPerf().worldTick);
   await page.getByRole('button', { name: 'Run replay', exact: true }).click();
   await page.waitForFunction(() => document.querySelector('sand-game').shadowRoot

--- a/src/sand/README.md
+++ b/src/sand/README.md
@@ -225,13 +225,13 @@ more of the world.
 Pressing `L` while the local simulation surface owns keyboard input pauses the
 authority and opens the deterministic replay panel. Its copy/paste capsule keeps
 the real generated seed, initialization options, authority-turn input/config/
-resize events, streaming transport gates, and the exact time sampled by each
-continuous-tool turn. Replaying reconstructs a fresh authority and verifies the
-final tick, streamed offset, actor/topology totals, and both-layer grid checksum.
+resize events, the total turn count, and sparse ranges for streaming transport
+gates. Continuous tools use deterministic turn time. Replaying reconstructs a
+fresh authority and verifies the final tick, streamed offset, actor/topology
+totals, and both-layer grid checksum.
 Capsules are ABI-versioned and intentionally reject incompatible engine builds;
 multiplayer sessions cannot be captured because their authority is remote.
-The text codec stores turn-time deltas and compact turn/event arrays before
-optional gzip compression.
+The copy/paste format is plain JSON with compact event and gate entries.
 
 ## Source map
 

--- a/src/sand/game/replayCapsule.js
+++ b/src/sand/game/replayCapsule.js
@@ -2,8 +2,8 @@ import { ABI_FINGERPRINT, ABI_VERSION } from '../wasmBridge/abi.generated.js';
 import { ENGINE_MAX_CELLS, ENGINE_MAX_DIMENSION } from '../engineLimits.js';
 
 export const REPLAY_FORMAT = 'sand-input-replay';
-export const REPLAY_VERSION = 1;
-export const REPLAY_PREFIX = 'SAND-REPLAY-1:';
+export const REPLAY_VERSION = 2;
+export const REPLAY_PREFIX = 'SAND-REPLAY-2:';
 
 export const REPLAY_EVENT_TYPES = new Set([
   'control', 'input', 'intent', 'edge', 'config', 'resize',
@@ -40,28 +40,31 @@ export function validateReplayCapsule(value) {
 
   const turns = value.turns;
   const events = value.events;
-  if (!Array.isArray(turns) || turns.length > MAX_REPLAY_TURNS)
-    throw new Error('Replay turn list is invalid or too large.');
+  const gates = value.gates;
+  if (!finiteInteger(turns, 0, MAX_REPLAY_TURNS))
+    throw new Error('Replay turn count is invalid or too large.');
   if (!Array.isArray(events) || events.length > MAX_REPLAY_TURNS * 4)
     throw new Error('Replay event list is invalid or too large.');
-  for (const turn of turns) {
-    if (!turn || typeof turn !== 'object'
-        || !Number.isFinite(turn.now) || turn.now < 0
-        || typeof turn.awaitingAck !== 'boolean'
-        || typeof turn.fullResyncRequested !== 'boolean'
-        || (turn.inputSeq !== null
-          && !finiteInteger(turn.inputSeq, 0, 0xffffffff)))
-      throw new Error('Replay contains an invalid turn timestamp.');
-  }
+  if (!Array.isArray(gates) || gates.length > MAX_REPLAY_TURNS)
+    throw new Error('Replay transport gate list is invalid or too large.');
   let previousTick = -1;
   for (const event of events) {
     if (!event || typeof event !== 'object'
-        || !finiteInteger(event.tick, 0, turns.length)
+        || !finiteInteger(event.tick, 0, turns)
         || event.tick < previousTick
         || !event.message || typeof event.message !== 'object'
         || !REPLAY_EVENT_TYPES.has(event.message.type))
       throw new Error('Replay contains an invalid authority event.');
     previousTick = event.tick;
+  }
+  let previousEnd = 0;
+  for (const gate of gates) {
+    if (!gate || typeof gate !== 'object'
+        || !finiteInteger(gate.start, previousEnd, turns)
+        || !finiteInteger(gate.end, gate.start + 1, turns)
+        || !finiteInteger(gate.flags, 1, 3))
+      throw new Error('Replay contains an invalid transport gate range.');
+    previousEnd = gate.end;
   }
 
   const final = value.final;
@@ -79,123 +82,42 @@ export function validateReplayCapsule(value) {
 }
 
 function packReplayCapsule(capsule) {
-  let previousNow = 0;
-  const turns = capsule.turns.map((turn) => {
-    const delta = turn.now - previousNow;
-    const time = previousNow + delta === turn.now ? delta : [turn.now];
-    previousNow = turn.now;
-    const flags = (turn.awaitingAck ? 1 : 0)
-      | (turn.fullResyncRequested ? 2 : 0);
-    return [time, flags, turn.inputSeq];
-  });
-  return [
-    capsule.abiVersion,
-    capsule.abiFingerprint,
-    capsule.init,
-    turns,
-    capsule.events.map((event) => [event.tick, event.message]),
-    capsule.view || {},
-    capsule.final,
-  ];
-}
-
-function unpackReplayCapsule(value) {
-  if (!Array.isArray(value) || value.length !== 7
-      || !Array.isArray(value[3]) || !Array.isArray(value[4]))
-    throw new Error('This is not a supported sand replay capsule.');
-  let previousNow = 0;
-  const turns = value[3].map(([time, flags, inputSeq]) => {
-    const now = Array.isArray(time) ? time[0] : previousNow + time;
-    previousNow = now;
-    return {
-      now,
-      awaitingAck: !!(flags & 1),
-      fullResyncRequested: !!(flags & 2),
-      inputSeq,
-    };
-  });
   return {
-    format: REPLAY_FORMAT,
-    version: REPLAY_VERSION,
-    abiVersion: value[0],
-    abiFingerprint: value[1],
-    init: value[2],
-    turns,
-    events: value[4].map(([tick, message]) => ({ tick, message })),
-    view: value[5],
-    final: value[6],
+    ...capsule,
+    events: capsule.events.map((event) => [event.tick, event.message]),
+    gates: capsule.gates.map((gate) => [gate.start, gate.end, gate.flags]),
   };
 }
 
-function bytesToBase64(bytes) {
-  let binary = '';
-  const chunkSize = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
-  }
-  return btoa(binary);
+function unpackReplayCapsule(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+      || !Array.isArray(value.events) || !Array.isArray(value.gates))
+    throw new Error('This is not a supported sand replay capsule.');
+  return {
+    ...value,
+    events: value.events.map(([tick, message]) => ({ tick, message })),
+    gates: value.gates.map(([start, end, flags]) => ({ start, end, flags })),
+  };
 }
 
-function base64ToBytes(value) {
-  const binary = atob(value);
-  if (binary.length > MAX_REPLAY_TEXT_BYTES)
-    throw new Error('Replay capsule is too large.');
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
+const replayTextBytes = (text) => new TextEncoder().encode(text).length;
 
-async function readLimited(stream) {
-  const reader = stream.getReader();
-  const chunks = [];
-  let length = 0;
-  let finished = false;
-  while (!finished) {
-    const { value, done } = await reader.read();
-    if (done) { finished = true; continue; }
-    length += value.length;
-    if (length > MAX_REPLAY_TEXT_BYTES) {
-      await reader.cancel();
-      throw new Error('Replay capsule expands beyond the size limit.');
-    }
-    chunks.push(value);
-  }
-  const bytes = new Uint8Array(length);
-  let offset = 0;
-  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.length; }
-  return bytes;
-}
-
-export async function encodeReplayCapsule(capsule) {
+export function encodeReplayCapsule(capsule) {
   validateReplayCapsule(capsule);
-  const bytes = new TextEncoder().encode(JSON.stringify(packReplayCapsule(capsule)));
-  if (typeof CompressionStream === 'function') {
-    const compressed = await readLimited(
-      new Blob([bytes]).stream().pipeThrough(new CompressionStream('gzip')),
-    );
-    return `${REPLAY_PREFIX}gzip:${bytesToBase64(compressed)}`;
-  }
-  return `${REPLAY_PREFIX}json:${bytesToBase64(bytes)}`;
+  const text = `${REPLAY_PREFIX}${JSON.stringify(packReplayCapsule(capsule))}`;
+  if (replayTextBytes(text) > MAX_REPLAY_TEXT_BYTES)
+    throw new Error('Replay capsule is too large.');
+  return text;
 }
 
-export async function decodeReplayCapsule(text) {
+export function decodeReplayCapsule(text) {
   const compact = String(text || '').trim();
   if (!compact.startsWith(REPLAY_PREFIX))
-    throw new Error('Replay text must start with SAND-REPLAY-1:.');
+    throw new Error('Replay text must start with SAND-REPLAY-2:.');
+  if (replayTextBytes(compact) > MAX_REPLAY_TEXT_BYTES)
+    throw new Error('Replay capsule is too large.');
   const payload = compact.slice(REPLAY_PREFIX.length);
-  const separator = payload.indexOf(':');
-  if (separator < 0) throw new Error('Replay text is incomplete.');
-  const encoding = payload.slice(0, separator);
-  let bytes = base64ToBytes(payload.slice(separator + 1));
-  if (encoding === 'gzip') {
-    if (typeof DecompressionStream !== 'function')
-      throw new Error('This browser cannot decompress replay capsules.');
-    bytes = await readLimited(
-      new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip')),
-    );
-  } else if (encoding !== 'json') {
-    throw new Error('Replay text uses an unknown encoding.');
-  }
-  const value = JSON.parse(new TextDecoder().decode(bytes));
+  if (!payload) throw new Error('Replay text is incomplete.');
+  const value = JSON.parse(payload);
   return validateReplayCapsule(unpackReplayCapsule(value));
 }

--- a/src/sand/game/replayPanel.js
+++ b/src/sand/game/replayPanel.js
@@ -110,7 +110,7 @@ export function createReplayPanel(ctx) {
       const text = await encodeReplayCapsule(capsule);
       if (generation !== openGeneration) return;
       textarea.value = text;
-      status.textContent = `${capsule.turns.length.toLocaleString()} authority turns and ${capsule.events.length.toLocaleString()} events captured. Paste another capsule here to replay it.`;
+      status.textContent = `${capsule.turns.toLocaleString()} authority turns and ${capsule.events.length.toLocaleString()} events captured. Paste another capsule here to replay it.`;
       textarea.focus({ preventScroll: true });
       textarea.select();
     } catch (error) {
@@ -147,7 +147,7 @@ export function createReplayPanel(ctx) {
     status.textContent = 'Decoding replay capsule…';
     try {
       const capsule = await decodeReplayCapsule(textarea.value);
-      status.textContent = `Replaying ${capsule.turns.length.toLocaleString()} authority turns…`;
+      status.textContent = `Replaying ${capsule.turns.toLocaleString()} authority turns…`;
       const result = await ctx.worldWorker.runReplay(capsule, (turn, turns) => {
         status.textContent = `Replaying turn ${turn.toLocaleString()} / ${turns.toLocaleString()}…`;
       });

--- a/src/sand/worker/worldWorker.js
+++ b/src/sand/worker/worldWorker.js
@@ -78,6 +78,8 @@ let replayCaptureStarting = false;
 let replayInputSignature = '';
 let replayRunning = false;
 let replayTransportSuppressed = false;
+const REPLAY_GATE_AWAITING_ACK = 1;
+const REPLAY_GATE_FULL_RESYNC = 2;
 const turnDeadline = createTurnDeadline({ now: performance.now() });
 
 function replayInitOptions(data) {
@@ -96,7 +98,8 @@ function beginReplayCapture(data) {
     abiFingerprint: ABI_FINGERPRINT,
     init: replayInitOptions(data),
     events: [],
-    turns: [],
+    gates: [],
+    turns: 0,
   };
 }
 
@@ -104,32 +107,39 @@ function recordReplayMessage(data) {
   if (!replayCapture || replayRunning || !REPLAY_EVENT_TYPES.has(data.type)) return;
   if (data.type === 'input') return;
   replayCapture.events.push({
-    tick: replayCaptureStarting ? 0 : replayCapture.turns.length,
+    tick: replayCaptureStarting ? 0 : replayCapture.turns,
     message: copyReplayValue(data),
   });
 }
 
-function recordReplayTurn(started) {
-  let inputSeq = null;
+function recordReplayTurn() {
   if (latestInput) {
-    inputSeq = latestInput.seq >>> 0;
     const inputState = copyReplayValue(latestInput);
     delete inputState.seq;
     const signature = JSON.stringify(inputState);
     if (signature !== replayInputSignature) {
       replayInputSignature = signature;
       replayCapture.events.push({
-        tick: replayCapture.turns.length,
+        tick: replayCapture.turns,
         message: { type: 'input', input: copyReplayValue(latestInput) },
       });
     }
   }
-  replayCapture.turns.push({
-    now: started,
-    awaitingAck,
-    fullResyncRequested,
-    inputSeq,
-  });
+  const flags = (awaitingAck ? REPLAY_GATE_AWAITING_ACK : 0)
+    | (fullResyncRequested ? REPLAY_GATE_FULL_RESYNC : 0);
+  if (flags) {
+    const previous = replayCapture.gates.at(-1);
+    if (previous?.end === replayCapture.turns && previous.flags === flags) {
+      previous.end++;
+    } else {
+      replayCapture.gates.push({
+        start: replayCapture.turns,
+        end: replayCapture.turns + 1,
+        flags,
+      });
+    }
+  }
+  replayCapture.turns++;
 }
 
 function replayFinalState() {
@@ -585,7 +595,8 @@ function executeTurn(started, scheduleNext = true) {
   }
   if (!survival) {
     applyEdges();
-    applyContinuous(started);
+    // Held-tool cadence belongs to authority turn time, independent of worker scheduling jitter.
+    applyContinuous(engine.getTick() * SIM_STEP_MS);
   }
   const stepStart = performance.now();
   if (survival && latestInput && localPlayerId) {
@@ -648,7 +659,7 @@ function run() {
     schedule();
     return;
   }
-  if (replayCapture) recordReplayTurn(started);
+  if (replayCapture) recordReplayTurn();
   executeTurn(started);
 }
 
@@ -855,7 +866,7 @@ function exportReplay(requestId, view) {
   const capsule = {
     ...replayCapture,
     events: replayCapture.events.slice(),
-    turns: replayCapture.turns.slice(),
+    gates: replayCapture.gates.slice(),
     view: copyReplayValue(view || {}),
     final: replayFinalState(),
   };
@@ -892,6 +903,7 @@ async function runReplayCapsule(requestId, value) {
   }
 
   let eventIndex = 0;
+  let gateIndex = 0;
   let turnIndex = 0;
   const applyEventsAtTurn = (turn) => {
     while (eventIndex < capsule.events.length
@@ -923,7 +935,7 @@ async function runReplayCapsule(requestId, value) {
       replayCapture = {
         ...capsule,
         events: capsule.events.slice(),
-        turns: capsule.turns.slice(),
+        gates: capsule.gates.slice(),
       };
       postFull('replay', { replayView: capsule.view || null });
       postActors(true);
@@ -939,23 +951,26 @@ async function runReplayCapsule(requestId, value) {
   const replaySlice = () => {
     if (closing || !replayRunning) return;
     try {
-      const end = Math.min(capsule.turns.length, turnIndex + 120);
+      const end = Math.min(capsule.turns, turnIndex + 120);
       while (turnIndex < end) {
         applyEventsAtTurn(turnIndex);
-        const turn = capsule.turns[turnIndex];
-        awaitingAck = turn.awaitingAck;
-        fullResyncRequested = turn.fullResyncRequested;
-        if (latestInput && turn.inputSeq !== null) latestInput.seq = turn.inputSeq;
-        executeTurn(turn.now, false);
+        while (gateIndex < capsule.gates.length
+               && capsule.gates[gateIndex].end <= turnIndex) gateIndex++;
+        const gate = capsule.gates[gateIndex];
+        const flags = gate && gate.start <= turnIndex && turnIndex < gate.end
+          ? gate.flags : 0;
+        awaitingAck = !!(flags & REPLAY_GATE_AWAITING_ACK);
+        fullResyncRequested = !!(flags & REPLAY_GATE_FULL_RESYNC);
+        executeTurn(performance.now(), false);
         turnIndex++;
       }
-      if (turnIndex >= capsule.turns.length) {
+      if (turnIndex >= capsule.turns) {
         finish();
         return;
       }
       self.postMessage({
         type: 'replay-progress', requestId,
-        turn: turnIndex, turns: capsule.turns.length,
+        turn: turnIndex, turns: capsule.turns,
       });
       setTimeout(replaySlice, 0);
     } catch (error) {


### PR DESCRIPTION
## Summary
- replace the per-turn timestamp/state array with one turn count plus sparse transport-gate ranges
- drive held creative tools from deterministic simulation-turn time, leaving the replay log focused on input/config/resize events
- replace gzip/base64 capsules with readable, versioned plain JSON and add focused codec coverage

## Verification
- `npm run test:replay`
- `node scripts/run-tests.mjs --only timing`
- `node scripts/run-tests.mjs --only worker-order`
- `npm run test:worker-e2e`
- `npm run build`
- ESLint on the changed source files

The browser replay suite verified the rebuilt authority final tick, streamed offset, actors, topology totals, and both-layer grid checksum.