### PR TITLE
Fix creative Q handling in Safari

### DIFF
--- a/scripts/worker-e2e.mjs
+++ b/scripts/worker-e2e.mjs
@@ -250,22 +250,62 @@ try {
       configuredPaint.before));
   const palette = page.locator('sand-game').locator('.sg-palette');
   await palette.locator('.sg-expand').click();
-  await palette.getByRole('option', { name: 'sand', exact: true }).click();
-  await palette.getByRole('option', { name: 'cube', exact: true }).click();
+  const searchTyping = await page.evaluate(() => {
+    const root = document.querySelector('sand-game').shadowRoot;
+    return {
+      focused: root.activeElement === root.querySelector('.sg-search'),
+      selected: root.querySelector('.sg-current .sg-name-track')?.textContent,
+    };
+  });
+  await page.keyboard.type('q');
+  const typedQuery = await page.evaluate(() => {
+    const root = document.querySelector('sand-game').shadowRoot;
+    return {
+      query: root.querySelector('.sg-search')?.value,
+      selected: root.querySelector('.sg-current .sg-name-track')?.textContent,
+    };
+  });
+  check('Q remains text while the material search owns the keyboard',
+    searchTyping.focused && typedQuery.query === 'q' &&
+      typedQuery.selected === searchTyping.selected);
+  await palette.locator('.sg-search').fill('');
+  const pointerPickFocused = await page.evaluate(() => {
+    const root = document.querySelector('sand-game').shadowRoot;
+    const option = (name) => [...root.querySelectorAll('.sg-opt')]
+      .find((node) => node.querySelector('.sg-name')?.textContent === name);
+    // HTMLElement.click() leaves the search focused unless the palette moves
+    // focus explicitly, matching pointer selection on browsers with that policy.
+    option('sand').click();
+    const cube = option('cube');
+    cube.click();
+    return root.activeElement === cube;
+  });
   const restoredPaint = await page.evaluate(() => {
     const root = document.querySelector('sand-game').shadowRoot;
     const rect = root.querySelector('#sand-main').getBoundingClientRect();
     const test = window.__sandTest;
-    const selectedOption = root.querySelector('.sg-opt.active');
-    selectedOption.focus({ preventScroll: true });
+    const activeElement = root.activeElement;
+    const nativeMatchMedia = window.matchMedia.bind(window);
+    window.matchMedia = (query) => query === '(pointer: coarse)'
+      ? { matches: true, media: query }
+      : nativeMatchMedia(query);
+    const movement = new KeyboardEvent('keydown', {
+      key: 'w', bubbles: true, composed: true, cancelable: true,
+    });
+    activeElement.dispatchEvent(movement);
+    activeElement.dispatchEvent(new KeyboardEvent('keyup', {
+      key: 'w', bubbles: true, composed: true,
+    }));
     const event = new KeyboardEvent('keydown', {
       key: 'q', bubbles: true, composed: true, cancelable: true,
     });
-    selectedOption.dispatchEvent(event);
+    activeElement.dispatchEvent(event);
+    window.matchMedia = nativeMatchMedia;
     return {
       x: rect.left + Math.floor(rect.width * 0.65),
       y: rect.top + Math.floor(rect.height * 0.14),
       before: test.materialCountBoth(1),
+      movementPrevented: movement.defaultPrevented,
       prevented: event.defaultPrevented,
       currentLabel: root.querySelector('.sg-current .sg-name-track')?.textContent,
       activeLabel: root.querySelector('.sg-opt.active .sg-name')?.textContent,
@@ -279,7 +319,8 @@ try {
     restoredPaint.before, { timeout: 10000 }).catch(() => {});
   const restoredSand = await page.evaluate(() => window.__sandTest.materialCountBoth(1));
   check('desktop Q restores the last creative selection after another tool is equipped',
-    restoredPaint.prevented && restoredPaint.currentLabel === 'sand' &&
+    pointerPickFocused && restoredPaint.movementPrevented && restoredPaint.prevented &&
+      restoredPaint.currentLabel === 'sand' &&
       restoredPaint.activeLabel === 'sand' && restoredSand > restoredPaint.before,
     `${restoredPaint.currentLabel}/${restoredPaint.activeLabel}, ${restoredPaint.before} -> ${restoredSand}`);
   await palette.getByRole('option', { name: 'cube', exact: true }).click();

--- a/src/sand/embed/toolPalette.js
+++ b/src/sand/embed/toolPalette.js
@@ -662,7 +662,11 @@ export function createToolPalette(root, { onSelectCreative, onToggleDrawMode, on
       lbl.className = 'sg-name';
       lbl.textContent = e.label;
       opt.append(renderSwatch(e), lbl);
-      opt.addEventListener('click', () => pick(e));
+      opt.addEventListener('click', () => {
+        // A desktop selection ends palette text entry and owns keyboard focus.
+        if (!atBottom) opt.focus({ preventScroll: true });
+        pick(e);
+      });
       optionByKey.set(e.key, opt);
       list.appendChild(opt);
     });

--- a/src/sand/game/inputBindings.js
+++ b/src/sand/game/inputBindings.js
@@ -42,8 +42,6 @@ export function createInputBindings(ctx, { refreshBounds, zoomBy, resetZoom, onI
     return b.width > 0 && b.height > 0 && b.right > 0 && b.bottom > 0 &&
       b.left < window.innerWidth && b.top < window.innerHeight;
   };
-  const hasDesktopPointer = () => !window.matchMedia
-    || !window.matchMedia('(pointer: coarse)').matches;
   const focusSurvivalSurfaceAtStartup = () => {
     if (!ctx.survival || !surfaceIsVisible()) return;
     const root = ctx.container.getRootNode?.();
@@ -191,7 +189,7 @@ export function createInputBindings(ctx, { refreshBounds, zoomBy, resetZoom, onI
     // surface focus.
     const visibleCreativeShortcut = !ctx.playMode && surfaceIsVisible() &&
       (key === 'w' || key === 'a' || key === 's' || key === 'd'
-        || (key === 'q' && hasDesktopPointer()));
+        || key === 'q');
     const visibleReplayKey = key === 'l' && surfaceIsVisible() && !ctx.playMode;
     if (!ownsKeyboard() && !visibleCreativeShortcut && !visibleReplayKey) return;
     if (key === 'l') { onReplay?.(); e.preventDefault(); return; }
@@ -214,7 +212,7 @@ export function createInputBindings(ctx, { refreshBounds, zoomBy, resetZoom, onI
       if (key === 'e') { onToggleInventory?.(); e.preventDefault(); return; }
       if (key === 'q') { onToggleFootprintMenu?.(); e.preventDefault(); return; }
     }
-    if (!ctx.survival && key === 'q' && hasDesktopPointer()) {
+    if (!ctx.survival && key === 'q') {
       onEquipLastCreativeMaterial?.();
       e.preventDefault();
       return;


### PR DESCRIPTION
## Fix
- keep Q as text while the palette search owns keyboard focus
- explicitly end desktop palette text entry after a material is selected
- make Q use the same creative keyboard context as WASD instead of a pointer media-query gate

## Verification
- focused browser reproduction covers Safari-style non-focusing option clicks
- search-focused Q remains text
- W and Q are both handled in camera-control context
- syntax, ESLint, and diff checks pass

The full worker E2E was also started, but timed out in its earlier replay-capture wait before reaching this Q assertion; deployment is proceeding per request and broader verification will continue afterward.