### PR TITLE
Give creative Q a reliable material fallback

### DIFF
--- a/scripts/worker-e2e.mjs
+++ b/scripts/worker-e2e.mjs
@@ -54,6 +54,23 @@ try {
       return (perf.workerStatus === 'live' || perf.workerStatus === 'live-no-diffs')
         && perf.workerProgressAgeMs < 2000;
     }));
+  await page.evaluate(() => {
+    document.querySelector('sand-game').shadowRoot.querySelector('.sg-sim')
+      .focus({ preventScroll: true });
+  });
+  await page.keyboard.press('q');
+  const freshCreativeQ = await page.evaluate(() => {
+    const root = document.querySelector('sand-game').shadowRoot;
+    const selected = root.querySelector('.sg-current .sg-name-track')?.textContent;
+    root.querySelector('.sg-expand').click();
+    const cube = [...root.querySelectorAll('.sg-opt')]
+      .find((node) => node.querySelector('.sg-name')?.textContent === 'cube');
+    cube.click();
+    root.querySelector('.sg-expand').click();
+    return selected;
+  });
+  check('fresh creative Q equips Sand before another material has been selected',
+    freshCreativeQ === 'sand', freshCreativeQ);
   const mirrorFailure = await page.evaluate(() => {
     const perf = window.__sandPerf();
     window.__sandTest.failNextMirrorApply();
@@ -269,22 +286,20 @@ try {
     searchTyping.focused && typedQuery.query === 'q' &&
       typedQuery.selected === searchTyping.selected);
   await palette.locator('.sg-search').fill('');
-  const pointerPickFocused = await page.evaluate(() => {
+  const pointerPickEndedSearch = await page.evaluate(() => {
     const root = document.querySelector('sand-game').shadowRoot;
     const option = (name) => [...root.querySelectorAll('.sg-opt')]
       .find((node) => node.querySelector('.sg-name')?.textContent === name);
-    // HTMLElement.click() leaves the search focused unless the palette moves
-    // focus explicitly, matching pointer selection on browsers with that policy.
+    const search = root.querySelector('.sg-search');
     option('sand').click();
-    const cube = option('cube');
-    cube.click();
-    return root.activeElement === cube;
+    option('cube').click();
+    return root.activeElement !== search;
   });
   const restoredPaint = await page.evaluate(() => {
     const root = document.querySelector('sand-game').shadowRoot;
     const rect = root.querySelector('#sand-main').getBoundingClientRect();
     const test = window.__sandTest;
-    const activeElement = root.activeElement;
+    const activeElement = root.activeElement || document.activeElement || document.body;
     const nativeMatchMedia = window.matchMedia.bind(window);
     window.matchMedia = (query) => query === '(pointer: coarse)'
       ? { matches: true, media: query }
@@ -319,7 +334,7 @@ try {
     restoredPaint.before, { timeout: 10000 }).catch(() => {});
   const restoredSand = await page.evaluate(() => window.__sandTest.materialCountBoth(1));
   check('desktop Q restores the last creative selection after another tool is equipped',
-    pointerPickFocused && restoredPaint.movementPrevented && restoredPaint.prevented &&
+    pointerPickEndedSearch && restoredPaint.movementPrevented && restoredPaint.prevented &&
       restoredPaint.currentLabel === 'sand' &&
       restoredPaint.activeLabel === 'sand' && restoredSand > restoredPaint.before,
     `${restoredPaint.currentLabel}/${restoredPaint.activeLabel}, ${restoredPaint.before} -> ${restoredSand}`);

--- a/src/sand/embed/toolPalette.js
+++ b/src/sand/embed/toolPalette.js
@@ -663,8 +663,8 @@ export function createToolPalette(root, { onSelectCreative, onToggleDrawMode, on
       lbl.textContent = e.label;
       opt.append(renderSwatch(e), lbl);
       opt.addEventListener('click', () => {
-        // A desktop selection ends palette text entry and owns keyboard focus.
-        if (!atBottom) opt.focus({ preventScroll: true });
+        // A desktop selection ends palette text entry before shortcuts resume.
+        if (!atBottom) search.blur();
         pick(e);
       });
       optionByKey.set(e.key, opt);

--- a/src/sand/game/createSandGame.js
+++ b/src/sand/game/createSandGame.js
@@ -16,6 +16,7 @@ import { createWorldWorkerClient } from '../worker/worldWorkerClient.js';
 import { createSandAudio } from '../audio/sandAudio.js';
 import { createReplayPanel } from './replayPanel.js';
 import { CREATIVE_KIND, CREATURE, MISSION } from '../wasmBridge/abi.generated.js';
+import { MAT } from '../materials.js';
 import { resolvePlanetId } from './planetSelection.js';
 
 export function createSandGame(container, opts = {}) {
@@ -131,7 +132,7 @@ export function createSandGame(container, opts = {}) {
     worldWorker: null,
     creativeKind: 0,
     creativeValue: 0,
-    lastCreativeMaterial: null,
+    lastCreativeMaterial: survival ? null : MAT.SAND,
     creatureSimulationRequested: false,
     inputSeq: 0,
 


### PR DESCRIPTION
## Root cause
A fresh creative session initialized its remembered material to `null`, so Q was handled but returned without changing the Cube tool. Reloading for each deployment guaranteed that path. Separately, macOS Safari can refuse button focus, leaving palette search as the keyboard owner after an option click.

## Fix
- seed fresh creative material history with Sand while keeping Cube initially equipped
- explicitly blur palette search after a desktop option selection instead of depending on button focus
- preserve Q as ordinary text whenever search is actively focused

## Verification
Focused browser regression passes: fresh Cube + Q => Sand; Safari-style non-focusing Sand/Cube clicks + Q => Sand; focused search + Q => query text with no tool swap. Syntax, ESLint, and diff checks pass.